### PR TITLE
feat(debug): allow logs on debug mode only

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -43,12 +43,15 @@ export default defineNuxtConfig({
       clientSecret: 'secret',
       callbackUrl: '',
       scope: [
+        'openid',
         'email',
-        'profile'
+        'profile',
+        // 'address'
       ]
     },
     config: {
-      response_type: 'id_token',
+      debug: true,
+      response_type: 'code',
       secret: 'oidc._sessionid',
       cookie: { loginName: '' },
       cookiePrefix: 'oidc._',

--- a/playground/pages/[...slug].vue
+++ b/playground/pages/[...slug].vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <NavBar />
+    <main class="container">
+      <h1> 401 Unauthenticated</h1>
+    </main>
+  </div>
+</template>
+
+<script lang="ts" >
+</script>

--- a/playground/pages/public.vue
+++ b/playground/pages/public.vue
@@ -2,6 +2,7 @@
   <div>
     <NavBar />
     <main class="container">
+      <h1> Public Page </h1>
       <b-alert show variant="success">
         You should see this page without need to authentication!
       </b-alert>

--- a/playground/pages/secure.vue
+++ b/playground/pages/secure.vue
@@ -2,12 +2,18 @@
   <div>
     <NavBar />
     <main class="container">
+      <h1> Secure Page </h1>
       <b-alert show variant="success">
-        You should see this page without need to authentication!
+        Secured content
+        You should see this page <b> only if authenticated!</b>
       </b-alert>
     </main>
   </div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
+const { $oidc } = useNuxtApp()
+if(!$oidc.isLoggedIn) {
+  navigateTo('/401');
+}
 </script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'url'
-import { defineNuxtModule, addPlugin, resolveModule, createResolver } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, resolveModule, createResolver } from '@nuxt/kit';
 import defu from 'defu'
 import { name, version } from '../package.json'
+import { logger } from './runtime/utils/logger';
+
 
 export type CookieSerializeOptions = {
   domain?: string | undefined;
@@ -35,6 +37,7 @@ export type Config = {
   cookieFlags?: {
     [key: string]: CookieSerializeOptions,
   }
+  debug?: boolean | undefined,
 }
 
 export interface ModuleOptions {
@@ -61,13 +64,11 @@ export default defineNuxtModule<ModuleOptions>({
       clientSecret: '',
       callbackUrl: '',
       scope: [
-        'email',
-        'profile',
-        'address'
       ]
     },
     // express-session configuration
     config: {
+      debug: false,
       secret: 'oidc._sessionid', // process.env.OIDC_SESSION_SECRET
       cookie: {},
       cookiePrefix: 'oidc._',
@@ -80,8 +81,12 @@ export default defineNuxtModule<ModuleOptions>({
       cookieFlags: {}
     }
   },
-  setup (options, nuxt) {
-    // console.log(options.op)
+  setup(options, nuxt) {
+    logger.level = options.config.debug == true ? 5 : 0 // 4 = debug, 5 = trace
+    logger.info('[DEBUG MODE]: ', options.config.debug);
+    logger.debug('[WITHOUT ENV VARS] options:', options);
+
+
     const { resolve } = createResolver(import.meta.url)
     const resolveRuntimeModule = (path: string) => resolveModule(path, { paths: resolve('./runtime') })
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -3,6 +3,7 @@ import { Storage, StorageOptions } from './storage'
 import { isUnset, isSet } from './utils/utils'
 import { encrypt, decrypt } from './utils/encrypt'
 import { useState, useFetch, useRuntimeConfig, useCookie } from '#imports'
+import { logger } from '@nuxt/kit'
 
 interface UseState {
   user: any,
@@ -14,7 +15,7 @@ class Oidc {
   private $useState: any // State: Nuxt.useState (share state in all nuxt pages and components) https://v3.nuxtjs.org/guide/features/state-management
   public $storage: Storage // LocalStorage: Browser.localStorage （share state in all sites, use in page refresh.）
 
-  constructor () {
+  constructor() {
     this.state = { user: {}, isLoggedIn: false }
 
     this.$useState = useState<UseState>('useState', () => { return { user: {}, isLoggedIn: false } })
@@ -29,7 +30,7 @@ class Oidc {
     this.$storage = storage
   }
 
-  get user () {
+  get user() {
     const userInfoState = this.$useState.value.user
     const userInfoLS = this.$storage.getUserInfo()
     if ((isUnset(userInfoState))) {
@@ -42,14 +43,14 @@ class Oidc {
     // return this.state.user  // not auto update
   }
 
-  get isLoggedIn () {
+  get isLoggedIn() {
     const isLoggedIn = this.$useState.value.isLoggedIn
     const isLoggedInLS = this.$storage.isLoggedIn()
     // console.log('isLoggedIn', isLoggedIn, isLoggedInLS)
     return isLoggedIn || isLoggedInLS
   }
 
-  setUser (user: any) {
+  setUser(user: any) {
     this.state.user = user
     this.state.isLoggedIn = Object.keys(user).length > 0
 
@@ -59,7 +60,7 @@ class Oidc {
     this.$storage.setUserInfo(user)
   }
 
-  async fetchUser () {
+  async fetchUser() {
     try {
       if (process.server) {
         console.log('serve-render: fetchUser from cookie.')
@@ -93,7 +94,7 @@ class Oidc {
     }
   }
 
-  login (redirect = '/') {
+  login(redirect = '/') {
     if (process.client) {
       const params = new URLSearchParams({ redirect })
       const toStr = '/oidc/login' // + params.toString()
@@ -102,7 +103,7 @@ class Oidc {
     }
   }
 
-  logout () {
+  logout() {
     // TODO clear user info when accessToken expired.
     if (process.client) {
       this.$useState.value.user = {}
@@ -115,8 +116,11 @@ class Oidc {
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
+  // TODO: enable consola debug mode here instead of console.log
   console.log('--- Nuxt plugin: nuxt-openid-connect!')
   const oidc = new Oidc()
   nuxtApp.provide('oidc', oidc)
+  // console.log('--- Nuxt plugin: DEBUG MODE:' + useNuxtApp().ssrContext?.runtimeConfig.openidConnect.config.debug);
+
   oidc.fetchUser() // render both from server and client.
 })

--- a/src/runtime/server/routes/oidc/cbt.ts
+++ b/src/runtime/server/routes/oidc/cbt.ts
@@ -1,16 +1,17 @@
 import { defineEventHandler, setCookie, getCookie } from 'h3'
 import { CBT_PAGE_TEMPATE } from '../../../utils/template'
 import { useRuntimeConfig } from '#imports'
+import { logger } from '@nuxt/kit'
 
 export default defineEventHandler((event) => {
-  console.log('oidc/cbt calling')
+  logger.debug('[CBT]: oidc/cbt calling')
   const { config } = useRuntimeConfig().openidConnect
   const res = event.res
   const html = CBT_PAGE_TEMPATE
 
   const sessionkey = config.secret
   const sessionid = getCookie(event, sessionkey)
-  // console.log(sessionid)
+  // logger.debug('[CBT]:' + sessionid)
   /* setCookie(event, sessionkey, sessionid, {
     maxAge: 24 * 60 * 60 // oneday
   }) */

--- a/src/runtime/server/routes/oidc/login.ts
+++ b/src/runtime/server/routes/oidc/login.ts
@@ -3,9 +3,10 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { initClient } from '../../../utils/issueclient'
 import { useRuntimeConfig } from '#imports'
+import { logger } from '../../../utils/logger'
 
 export default defineEventHandler(async (event) => {
-  console.log('oidc/login calling')
+  logger.info('[Login]: oidc/login calling')
   const { op, config } = useRuntimeConfig().openidConnect
 
   const req = event.req
@@ -14,12 +15,12 @@ export default defineEventHandler(async (event) => {
   const sessionkey = config.secret
   let sessionid = getCookie(event, config.secret)
   if (!sessionid) {
-    // console.log('regenerate sessionid')
+    logger.trace('[Login]: regenerate sessionid')
     sessionid = uuidv4()
   }
 
   const callbackUrl = (op.callbackUrl && op.callbackUrl.length > 0) ? op.callbackUrl : 'http://' + req.headers.host + '/oidc/cbt'
-  // console.log('cabackurl:', callbackUrl, op.callbackUrl)
+  logger.trace('[Login]: cabackurl: ', callbackUrl, op.callbackUrl)
 
   const parameters = {
     redirect_uri: callbackUrl,
@@ -28,9 +29,9 @@ export default defineEventHandler(async (event) => {
     scope: op.scope.join(' ') // 'openid' will be added by default
   }
   const authUrl = issueClient.authorizationUrl(parameters)
-  // console.log(authUrl)
+  logger.trace('[Login]: Auth Url: ' + authUrl)
 
-  console.log(sessionid)
+  logger.debug('[Login]: sessionid: ' + sessionid)
   if (sessionid) {
     setCookie(event, sessionkey, sessionid, {
       maxAge: config.cookieMaxAge,

--- a/src/runtime/server/routes/oidc/logout.ts
+++ b/src/runtime/server/routes/oidc/logout.ts
@@ -1,9 +1,10 @@
 import { getCookie, deleteCookie, defineEventHandler } from 'h3'
 import { useRuntimeConfig } from '#imports'
+import { logger } from '../../../utils/logger'
 
 export default defineEventHandler((event) => {
   const res = event.res
-  console.log('oidc/logout calling')
+  logger.log('[LOGOUT]: oidc/logout calling')
 
   const { config } = useRuntimeConfig().openidConnect
   deleteCookie(event, config.secret)

--- a/src/runtime/server/routes/oidc/user.ts
+++ b/src/runtime/server/routes/oidc/user.ts
@@ -2,11 +2,12 @@ import { getCookie, deleteCookie, defineEventHandler } from 'h3'
 import { initClient } from '../../../utils/issueclient'
 import { encrypt, decrypt } from '../../../utils/encrypt'
 import { useRuntimeConfig } from '#imports'
+import { logger } from '../../../utils/logger'
 
 export default defineEventHandler(async (event) => {
   const { config, op } = useRuntimeConfig().openidConnect
-  console.log('oidc/user calling')
-  // console.log(req.headers.cookie)
+  logger.debug('[USER]: oidc/user calling')
+  logger.trace('[USER]: ' + event.req.headers.cookie)
 
   const sessionid = getCookie(event, config.secret)
   const accesstoken = getCookie(event, config.cookiePrefix + 'access_token')
@@ -30,7 +31,7 @@ export default defineEventHandler(async (event) => {
       }
       return userinfo
     } catch (err) {
-      console.log(err)
+      logger.error('[USER]: ' + err)
       deleteCookie(event, config.secret)
       deleteCookie(event, config.cookiePrefix + 'access_token')
       deleteCookie(event, config.cookiePrefix + 'user_info')
@@ -43,7 +44,7 @@ export default defineEventHandler(async (event) => {
       return {}
     }
   } else {
-    console.log('empty accesstoken for access userinfo')
+    logger.debug('[USER]: empty accesstoken for access userinfo')
     return {}
   }
 })

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,28 +1,28 @@
 import { isUnset, isSet } from './utils/utils'
 
 export type StorageOptions = {
-    localStorage: boolean,
-    prefix: string,
-    ignoreExceptions: boolean
+  localStorage: boolean,
+  prefix: string,
+  ignoreExceptions: boolean
 }
 
 export class Storage {
   public options: StorageOptions
   private userInfoKey: string
 
-  constructor (options: StorageOptions) {
+  constructor(options: StorageOptions) {
     this.options = options
     this.userInfoKey = 'user'
   }
 
-  getPrefix (): string {
+  getPrefix(): string {
     if (!this.options.localStorage) {
       throw new Error('Cannot get prefix; localStorage is off')
     }
     return this.options.prefix
   }
 
-  setUserInfo (user:any) {
+  setUserInfo(user: any) {
     if (isUnset(user)) {
       return
     }
@@ -35,7 +35,7 @@ export class Storage {
     this.setLocalStorage(this.userInfoKey, _userValue)
   }
 
-  getUserInfo (): any {
+  getUserInfo(): any {
     if (this.isLocalStorageEnabled()) {
       const _user = this.getLocalStorage(this.userInfoKey)
       try {
@@ -48,18 +48,18 @@ export class Storage {
     }
   }
 
-  removeUserInfo (): void {
+  removeUserInfo(): void {
     if (this.isLocalStorageEnabled()) {
       this.removeLocalStorage(this.userInfoKey)
     }
   }
 
-  isLoggedIn (): boolean {
+  isLoggedIn(): boolean {
     const user = this.getUserInfo()
     return isSet(user) && Object.keys(user).length > 0
   }
 
-  setLocalStorage (key: string, value: string): string | void {
+  setLocalStorage(key: string, value: string): string | void {
     // Unset null, undefined
     if (isUnset(value)) {
       return this.removeLocalStorage(key)
@@ -82,7 +82,7 @@ export class Storage {
     return value
   }
 
-  getLocalStorage (key: string): string {
+  getLocalStorage(key: string): string {
     if (!this.isLocalStorageEnabled()) {
       return
     }
@@ -94,7 +94,7 @@ export class Storage {
     return value
   }
 
-  removeLocalStorage (key: string): void {
+  removeLocalStorage(key: string): void {
     if (!this.isLocalStorageEnabled()) {
       return
     }
@@ -104,7 +104,7 @@ export class Storage {
   }
 
   // origin from https://github.com/nuxt-community/auth-module
-  isLocalStorageEnabled (): boolean {
+  isLocalStorageEnabled(): boolean {
     // Local Storage only exists in the browser
     if (!process.client) {
       return false
@@ -123,7 +123,7 @@ export class Storage {
         // eslint-disable-next-line no-console
         console.warn(
           "[AUTH] Local storage is enabled in config, but browser doesn't" +
-                    ' support it'
+          ' support it'
         )
       }
       return false

--- a/src/runtime/utils/issueclient.ts
+++ b/src/runtime/utils/issueclient.ts
@@ -1,6 +1,8 @@
 import { Issuer } from 'openid-client'
 import { OidcProvider } from '../../module'
 import { useRuntimeConfig } from '#imports'
+import { logger } from './logger'
+
 
 export const initClient = async (op: OidcProvider, req: any) => {
   const { config } = useRuntimeConfig().openidConnect
@@ -8,7 +10,7 @@ export const initClient = async (op: OidcProvider, req: any) => {
   const callbackUrl = host ? 'http://' + host + '/oidc/cbt' : op.callbackUrl
 
   const issuer = await Issuer.discover(op.issuer)
-  // console.log('Discovered issuer %s %O', issuer.issuer, issuer.metadata)
+  logger.trace('Discovered issuer %s %O', issuer.issuer, issuer.metadata)
   const client = new issuer.Client({
     client_id: op.clientId,
     client_secret: op.clientSecret,

--- a/src/runtime/utils/logger.ts
+++ b/src/runtime/utils/logger.ts
@@ -1,0 +1,20 @@
+import { logger as initLogger } from "@nuxt/kit"
+
+const getLevel = (): number => { // load
+    try {
+        return useRuntimeConfig().openidConnect.config.debug ? 4 : 0 // 5: trace, 4: debug, 0: errors
+    } catch (error) {
+        return 0
+    }
+}
+
+// Note: tag not working after nuxt ready
+const logger = initLogger.create({
+    // level: 5,
+    defaults: {
+        tag: 'nuxt-opentid',
+    },
+    level: getLevel(),
+})
+
+export { logger }

--- a/src/runtime/utils/template.ts
+++ b/src/runtime/utils/template.ts
@@ -1,3 +1,4 @@
+const debug = useRuntimeConfig().openidConnect.config.debug ?? false
 export const CBT_PAGE_TEMPATE = `
 <!DOCTYPE html>
 <html>
@@ -8,7 +9,7 @@ export const CBT_PAGE_TEMPATE = `
 
   <script>
     const hash = window.location.hash
-    console.log(hash)
+    `+ (debug ? `console.log(hash)` : ``) + `
     if (hash.length > 0 && hash.includes('#')) {
       window.location.replace(window.location.href.replace('cbt#', 'callback?'))
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,7 +1650,7 @@ concat-map@0.0.1:
 
 consola@^2.15.3:
   version "2.15.3"
-  resolved "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
   integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
 
 console-control-strings@^1.0.0, console-control-strings@^1.1.0:


### PR DESCRIPTION
Features: 
- show logs only on debug mode [except for plugin]

Fixes: 
- fix scopes compatibility by removing all default scopes it's breaking in 0.4.3 because some scope are added by default. 
- playground minor enhancements

TODO: 
- debug mode for plugin. 
- fix the cookie serialization type. 

Regards, 