### PR TITLE
fix: [worker reload] [worker init] useRuntimeConfig is not defined   

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,9 +4,9 @@
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": [
-      "off"
+      "warn"
     ],
-    "no-console": "off",
+    "no-console": "warn",
     "vue/multi-word-component-names": "off"
   }
 }

--- a/playground/pages/[...slug].vue
+++ b/playground/pages/[...slug].vue
@@ -7,5 +7,5 @@
   </div>
 </template>
 
-<script lang="ts" >
+<script lang="ts">
 </script>

--- a/playground/pages/secure.vue
+++ b/playground/pages/secure.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts" setup>
 const { $oidc } = useNuxtApp()
-if(!$oidc.isLoggedIn) {
-  navigateTo('/401');
+if (!$oidc.isLoggedIn) {
+  navigateTo('/401')
 }
 </script>

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -3,7 +3,6 @@ import { Storage, StorageOptions } from './storage'
 import { isUnset, isSet } from './utils/utils'
 import { encrypt, decrypt } from './utils/encrypt'
 import { useState, useFetch, useRuntimeConfig, useCookie } from '#imports'
-import { logger } from '@nuxt/kit'
 
 interface UseState {
   user: any,
@@ -63,7 +62,7 @@ class Oidc {
   async fetchUser() {
     try {
       if (process.server) {
-        console.log('serve-render: fetchUser from cookie.')
+        // console.log('serve-render: fetchUser from cookie.')
         const { config } = useRuntimeConfig()?.public?.openidConnect
         const userinfoCookie = useCookie(config.cookiePrefix + 'user_info')
         if (isSet(userinfoCookie) && userinfoCookie.value) {
@@ -80,7 +79,7 @@ class Oidc {
         }
       } else {
         // this.$useState.value.user is set by server, and pass to client ? how achived it ?
-        console.log('client-render: fetchUser from server.')
+        // console.log('client-render: fetchUser from server.')
         const { data, pending, refresh, error } = await useFetch('/oidc/user')
         this.setUser(data.value)
         // console.log('fetchUser from server-api call.', data.value)
@@ -117,7 +116,7 @@ class Oidc {
 
 export default defineNuxtPlugin((nuxtApp) => {
   // TODO: enable consola debug mode here instead of console.log
-  console.log('--- Nuxt plugin: nuxt-openid-connect!')
+  // console.log('--- Nuxt plugin: nuxt-openid-connect!')
   const oidc = new Oidc()
   nuxtApp.provide('oidc', oidc)
   // console.log('--- Nuxt plugin: DEBUG MODE:' + useNuxtApp().ssrContext?.runtimeConfig.openidConnect.config.debug);

--- a/src/runtime/utils/template.ts
+++ b/src/runtime/utils/template.ts
@@ -1,4 +1,7 @@
+import { useRuntimeConfig } from '#imports';
+
 const debug = useRuntimeConfig().openidConnect.config.debug ?? false
+
 export const CBT_PAGE_TEMPATE = `
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION


This is an urgent fix for  ```[worker reload] [worker init] useRuntimeConfig is not defined``` caused to the unavailability of useRuntimeConfig 