### PR TITLE
feat: add composable `useOidc`

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -27,10 +27,12 @@
 </template>
 
 <script setup>
-// alternatively, you can also use it here
 import { version } from '../../package.json'
-const { $oidc } = useNuxtApp()
-console.log('here is 33 line..')
-console.log('isLogIn:', $oidc.isLoggedIn)
-// const user = useState('useState')
+
+// Access the plugin through the composable
+const oidc = useOidc()
+// Or through injected variable
+const { $oidc } = useNextApp()
+console.log('(composable) isLoggedIn:', oidc.isLoggedIn)
+console.log('(injected) isLoggedIn:', $oidc.isLoggedIn)
 </script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -161,6 +161,10 @@ export default defineNuxtModule<ModuleOptions>({
       const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
       nuxt.options.build.transpile.push(runtimeDir)
       addPlugin(resolve(runtimeDir, 'plugin'))
+
+      nuxt.hook('imports:dirs', (dirs) => {
+        dirs.push(resolve(runtimeDir, 'composables'))
+      })
     }
   }
 })

--- a/src/runtime/composables/useOidc.ts
+++ b/src/runtime/composables/useOidc.ts
@@ -1,0 +1,6 @@
+import { useNuxtApp } from '#app'
+import { type Oidc } from '../plugin'
+
+export default function useOidc(): Oidc {
+  return useNuxtApp().$oidc
+}

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -9,7 +9,7 @@ interface UseState {
   isLoggedIn: boolean
 }
 
-class Oidc {
+export class Oidc {
   private state: UseState // only this plugin.
   private $useState: any // State: Nuxt.useState (share state in all nuxt pages and components) https://v3.nuxtjs.org/guide/features/state-management
   public $storage: Storage // LocalStorage: Browser.localStorage （share state in all sites, use in page refresh.）


### PR DESCRIPTION
I added a composable to the plugin. 

While it's a preference, IMO it allows for slightly cleaner code while using this module.
Furthermore, having it in allows the developer to choose how to interact with the module.

e.g.

```
const { login } = useOidc()
await login('/secure')
```

instead of
```
const { $oidc } = useNuxtApp()
await $oidc.login('/secure')
```
or
```
const { $oidc: { login } } = useNuxtApp()
await login('/secure')
```