### PR TITLE
Remove Secret Cookie after verification

### DIFF
--- a/src/runtime/server/routes/oidc/callback.ts
+++ b/src/runtime/server/routes/oidc/callback.ts
@@ -1,5 +1,5 @@
 import * as http from 'http'
-import { defineEventHandler, getCookie, setCookie } from 'h3'
+import { defineEventHandler, getCookie, setCookie, deleteCookie } from 'h3'
 import { initClient } from '../../../utils/issueclient'
 import { encrypt } from '../../../utils/encrypt'
 import { logger } from '../../../utils/logger'
@@ -25,6 +25,7 @@ export default defineEventHandler(async (event) => {
   const { op, config } = useRuntimeConfig().openidConnect
   const responseMode = getResponseMode(config)
   const sessionid = getCookie(event, config.secret)
+  deleteCookie(event, config.secret)
   const redirectUrl = getRedirectUrl(req.url)
   // logger.info('---Callback. redirectUrl:' + redirectUrl)
   // logger.info(' -- req.url:' + req.url + '   #method:' + req.method + ' #response_mode:' + responseMode)


### PR DESCRIPTION
Hello again!
Thanks again for the awesome work, I love to use this package in my project!

As far as I know, the only task of the secret is to check whether the request to the OIDC provider was sent by our client or not. So I think we should remove the cookie, after wie loaded it into a variable in the callback file. The variable is later used to verify that the request was sent by that client and the cookie doesnt ever need to be used again.

What do you think?

Cheers