### PR TITLE
Configurable refresh token age when refresh age is not set.

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -60,6 +60,8 @@ export default defineNuxtConfig({
       cookieEncryptIV: 'ab83667c72eec9e4',
       cookieEncryptALGO: 'aes-256-cbc',
       cookieMaxAge: 24 * 60 * 60, //  default one day
+      hasCookieRefreshExpireDate: false, // Set this to true if your provider has an refresh_expires_in date for the refresh token
+      cookieRefreshDefaultMaxAge: 24 * 60 * 60, //  default one day if the hasCookieRefreshExpireDate is false
       cookieFlags: {
         access_token: {
           httpOnly: true,

--- a/src/runtime/utils/utils.ts
+++ b/src/runtime/utils/utils.ts
@@ -17,11 +17,16 @@ export const setCookieTokenAndRefreshToken = (event: any, config: any, tokenSet:
   }
 
   // refresh token setting
-  if (tokenSet && tokenSet.refresh_expires_in && tokenSet.refresh_token) {
-    setCookie(event, config.cookiePrefix + 'refresh_token', tokenSet.refresh_token, {
-      maxAge: tokenSet.refresh_expires_in
-    })
-  }
+    if (tokenSet && tokenSet.refresh_expires_in && tokenSet.refresh_token) {
+        setCookie(event, config.cookiePrefix + 'refresh_token', tokenSet.refresh_token, {
+            maxAge: tokenSet.refresh_expires_in
+        })
+    } else if (tokenSet && !config.hasCookieRefreshExpireDate && tokenSet.refresh_token) {
+        const expireDate = new Date(Date.now() + config.cookieRefreshDefaultMaxAge * 1000);
+        setCookie(event, config.cookiePrefix + 'refresh_token', tokenSet.refresh_token, {
+            expires: expireDate
+        })
+    }
 }
 
 export const setCookieInfo = async (event: any, config: any, userinfo: any) => {


### PR DESCRIPTION
Hello Aborn,

Thanks for all of the work here. 

My provider returns the refresh_token, but unfortunately does not return the token refresh_expires_in date. I would like to add a feature to allow for the refresh token to still be set if there is no refresh_expires_in in the response.

Please let me know if there needs to be change for this PR to be approved. Thanks