### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/playground/middleware/auth.ts
+++ b/playground/middleware/auth.ts
@@ -1,5 +1,5 @@
 export default defineNuxtRouteMiddleware((to, from) => {
-  if (process.server) { return }
+  if (import.meta.server) { return }
   const { $oidc } = useNuxtApp()
   if (!$oidc.isLoggedIn) {
     $oidc.login(to.fullPath)

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -61,7 +61,7 @@ export class Oidc {
 
   async fetchUser() {
     try {
-      if (process.server) {
+      if (import.meta.server) {
         // console.log('serve-render: fetchUser from cookie.')
         const { config } = useRuntimeConfig()?.openidConnect
         const userinfoCookie = useCookie(config.cookiePrefix + 'user_info')
@@ -94,7 +94,7 @@ export class Oidc {
   }
 
   login(redirect = '/') {
-    if (process.client) {
+    if (import.meta.client) {
       const params = new URLSearchParams({ redirect })
       const toStr = '/oidc/login?' + params.toString()
       window.location.replace(toStr)
@@ -103,7 +103,7 @@ export class Oidc {
 
   logout() {
     // TODO clear user info when accessToken expired.
-    if (process.client) {
+    if (import.meta.client) {
       this.$useState.value.user = {}
       this.$useState.value.isLoggedIn = false
 

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -106,7 +106,7 @@ export class Storage {
   // origin from https://github.com/nuxt-community/auth-module
   isLocalStorageEnabled(): boolean {
     // Local Storage only exists in the browser
-    if (!process.client) {
+    if (!import.meta.client) {
       return false
     }
 


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)